### PR TITLE
Make CPE matching case insensitive

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
+
+use devenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --all-extras
+
     - name: Pre-commit checks
       run: |
-        poetry run pre-commit run -a
+        poetry run -- pre-commit run --config .pre-commit-ci.yaml --all-files
+
     - name: Test
       run: |
         poetry run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,8 @@ nosetests.xml
 output/*.html
 output/*/index.html
 
-# Sphinx
-docs/_build
+.devenv*
+devenv.local.nix
 
-# Cookiecutter
-output/
-.pytest_cache/
-dist/
+.direnv
+.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+.venvs/
 
 # C extensions
 *.so

--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ".*\\.md"
@@ -13,13 +13,11 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.2"
+    rev: "v0.7.3"
     hooks:
       - id: ruff
         name: Check python (ruff)
-        args: [--show-source, --fix, --show-fixes, --exit-non-zero-on-fix]
-      - id: ruff-format
-        name: Format python (ruff)
+        args: [--config, pyproject.toml]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.21.0

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,24 @@
+help:
+    @just --list
+
+# Install all supported Python versions and dependencies in separate virtualenvs
+install-all:
+    #!/usr/bin/env bash
+    for version in 3.8 3.9 3.10 3.11 3.12 3.13; do \
+        run-python-version $version poetry install
+    done
+
+# Run tests with all supported Python versions
+test-all:
+    #!/usr/bin/env bash
+    for version in 3.8 3.9 3.10 3.11 3.12 3.13; do
+        run-python-version $version python$version -m pytest
+    done
+
+# Run checks (lints, formatting)
+check:
+    pre-commit run --all-files
+
+# Completely wipe the development environment and start from scratch
+reset-devenv:
+    rm -rf .venvs .direnv .pre-commit-config.yaml .pytest_cache .ruff_cache

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # cpematcher
 
-[![Build Status](https://travis-ci.com/alertot/cpematcher.svg?branch=master)](https://travis-ci.com/alertot/cpematcher)  [![PyPIersion](https://badge.fury.io/py/cpematcher.svg)](https://badge.fury.io/py/cpematcher)
-
-## Overview
-
 Match and compare CPEs.
 
 ## Installation / Usage
@@ -12,8 +8,21 @@ To install use pip:
 
     $ pip install cpematcher-ng
 
-
-
 # Origin
 
 The project was forked from [cpematcher](https://github.com/alertot/cpematcher). Kudos to the original author!
+
+# Development
+
+We use [devenv](https://devenv.sh) and [direnv]() for development.
+You can setup virtualenvs for all supported Python versions:
+
+```shell
+$ just install-versions
+```
+
+And run all checks and tests after that:
+
+```shell
+$ just check test-all
+```

--- a/cpematcher/core.py
+++ b/cpematcher/core.py
@@ -77,6 +77,7 @@ class CPE:
 
     @staticmethod
     def _glob_equal(value1: str, value2: str) -> bool:
+        value1, value2 = value1.lower(), value2.lower()
         # Depending on the order, fnmatch.fnmatch could return False if wildcard
         # is the first value. As wildcard should always return True in any case,
         # we reorder the arguments based on that.

--- a/cpematcher/core.py
+++ b/cpematcher/core.py
@@ -23,14 +23,6 @@ class CPE:
         "other",
     ]
 
-    @property
-    def matches_all(self):
-        return self.version == "*" and not (
-            self.version_start_including
-            or self.version_start_excluding
-            or self.version_end_including
-            or self.version_end_excluding
-        )
 
     def __init__(
         self,

--- a/cpematcher/utils.py
+++ b/cpematcher/utils.py
@@ -1,8 +1,9 @@
 import contextlib
+from typing import List
 
 
 # heavily inspired by https://stackoverflow.com/a/21882672
-def split_cpe_string(string):
+def split_cpe_string(string: str) -> List[str]:
     ret = []
     current = []
     itr = iter(string)

--- a/cpematcher/version.py
+++ b/cpematcher/version.py
@@ -5,7 +5,7 @@ from natsort import natsorted
 
 class Version:
     def __init__(self, version: Optional[str]):
-        self.version = version
+        self.version = version and version.lower()
 
     def __bool__(self):
         return bool(self.version)

--- a/cpematcher/version.py
+++ b/cpematcher/version.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from natsort import natsorted
 
 
 class Version:
-    def __init__(self, version):
+    def __init__(self, version: Optional[str]):
         self.version = version
 
     def __bool__(self):

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,152 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1731679695,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "9f6cadacb9db82f541bbadd67e0189a2b850937e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731531548,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730716553,
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "8fcdb8ec34a1c2bae3f5326873a41b310e948ccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1731386116,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1731363552,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,47 @@
+{ pkgs, lib, config, inputs, ... }:
+let
+  root-dir = config.devenv.root;
+in
+{
+  # https://devenv.sh/basics/
+
+  # https://devenv.sh/packages/
+  packages = [ pkgs.git ];
+
+  # https://devenv.sh/languages/
+  languages.python = {
+    enable = true;
+    version = "3.11";
+    poetry = {
+      enable = true;
+      activate.enable = true;
+      install.enable = true;
+      install.verbosity = "little";
+    };
+  };
+
+  # https://devenv.sh/scripts/
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    python -m pytest tests/
+  '';
+
+  # https://devenv.sh/pre-commit-hooks/
+  pre-commit.hooks = {
+    ruff = {
+      enable = true;
+      args = [ "--config" "${root-dir}/pyproject.toml" ];
+    };
+    ruff-format.enable = true;
+    check-added-large-files.enable = true;
+    trim-trailing-whitespace = {
+      enable = true;
+      excludes = [ ".*.md$" ];
+    };
+    end-of-file-fixer.enable = true;
+  };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,10 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+
+allowUnfree: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpematcher-ng"
-version = "1.0.1"
+version = "1.1.0"
 description = "Match and compare CPEs."
 homepage = "https://github.com/onekey-sec/cpematcher-ng"
 authors = ["ONEKEY <support@onekey.com>", "alertot SpA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py311"
 
+[tool.ruff.lint]
 select = [
   "C90",    # mccabe
   "C4",     # flake8-comprehensions
@@ -56,13 +57,5 @@ ignore = [
   "RUF012",  # mutable-class-default: Wants to annotate things like `__mapper_args__` with `ClassVar`, producing noise
 ]
 
-# Do not remove unused imports automatically in __init__.py files
-ignore-init-module-imports = true
-
-[tool.ruff.per-file-ignores]
-"*/__init__.py" = [
-  "F401"
-]
-
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ select = [
   "PIE",    # flake8-pie
   "RUF",    # ruff's own lints
   "SIM",    # flake8-simplify
-  "UP",     # pyupgrade
   "W",      # pycodestyle (warnings)
 ]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,8 +50,20 @@ class TestCPE:
 
     def test_matches_with_exact_version(self):
         version_cpe = CPE("cpe:2.3:a:apache:activemq:4.1.1:*:*:*:*:*:*:*")
-
         assert version_cpe.matches(version_cpe)
+
+    def test_matches_case_insensitive(self):
+        cpe_str = "cpe:2.3:a:apache:activemq:4.1.1:*:*:*:*:*:*:*"
+        cpe = CPE(cpe_str)
+        upper_cpe = CPE(cpe_str.replace("apche", "APACHE"))
+        assert cpe.matches(upper_cpe)
+
+        cpe_alnum_version = (
+            "cpe:2.3:o:microsoft:windows_server_2008:r2:sp1:*:*:*:*:x64:*"
+        )
+        alnum_cpe = CPE(cpe_alnum_version)
+        cpe_alnum_upper = CPE(cpe_alnum_version.replace("r2:sp1", "R2:SP1"))
+        assert alnum_cpe.matches(cpe_alnum_upper)
 
     def test_matches_with_version_start_including(self):
         branch_cpe = CPE(self.template % "4.1.*", version_start_including="4.1.3")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,33 +24,6 @@ class TestCPE:
         with pytest.raises(ValueError):
             CPE("cpe:2.3:a:apache:activemq:4.0.1:*:*:*:*:*")
 
-    def test_matches_all(self):
-        cpe = CPE("cpe:2.3:a:apache:activemq:4.0.1:*:*:*:*:*:*:*")
-        assert not cpe.matches_all
-
-        cpe = CPE("cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*")
-        assert cpe.matches_all
-
-        cpe = CPE(
-            "cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*", version_start_including="1"
-        )
-        assert not cpe.matches_all
-
-        cpe = CPE(
-            "cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*", version_start_excluding="1"
-        )
-        assert not cpe.matches_all
-
-        cpe = CPE(
-            "cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*", version_end_including="1"
-        )
-        assert not cpe.matches_all
-
-        cpe = CPE(
-            "cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*", version_end_excluding="1"
-        )
-        assert not cpe.matches_all
-
     def test_matches_with_wildcard(self):
         master_cpe = CPE("cpe:2.3:a:apache:activemq:*:*:*:*:*:*:*:*")
         version_cpe = CPE("cpe:2.3:a:apache:activemq:4.0.1:*:*:*:*:*:*:*")


### PR DESCRIPTION
According to [Common Platform Enumeration: Naming Specification Version 2.3](https://csrc.nist.gov/pubs/ir/7695/final) Section 2.3
and
[Common Platform Enumeration: Name Matching Specification Version 2.3](https://csrc.nist.gov/pubs/ir/7696/final) Section 7.3 and 6.1.3.2,

CPE attributes should be lowercased before comparing them.

In practice, all CPEs in the CVE Database are in lowercase, that shouldn't be a problem, but comparing with user input (like CPE coming from an SBOM) should work according to the specification.
